### PR TITLE
Bad PDF path

### DIFF
--- a/data/tei/H16N1Reif_Penn.xml
+++ b/data/tei/H16N1Reif_Penn.xml
@@ -52,7 +52,7 @@
                     <analytic>
                         <author>Elizabeth Reif and Michael Penn</author>
                         <title level="a">The Wright Decoder: A Page Index to the Catalogue of Syriac Manuscripts in the British Museum</title>
-                        <idno type="PDF">https://hugoye.bethmardutho.org/pdf/vol16/H16N1Reif_Penn.pdf.pdf</idno>
+                        <idno type="PDF">https://hugoye.bethmardutho.org/pdf/vol16/H16N1Reif_Penn.pdf</idno>
                         <idno type="URI"/><!-- Insert Syriaca bibl URI when available --><!-- Don't do anything here yet -->
                     </analytic>
                     <monogr>


### PR DESCRIPTION
Fixing a PDF link on an old article: H16N1Reif_Penn